### PR TITLE
.travis.yml: Report coverage with codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ install:
   - make
   - sudo make install
   - popd
-  - pip install coveralls lxml tox
+  - pip install codecov lxml tox
   - python setup.py bdist_wheel
   - pip install --use-wheel ./dist/vulture_whitelist*.whl
 script:
   - tox -e cleanup,py,docs,style,vulture
 after_success:
-  - coveralls
+  - codecov

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 vulture-whitelist-generators
 ============================
 
+.. image:: https://codecov.io/gh/RJ722/vulture-whitelist-generators/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/RJ722/vulture-whitelist-generators
+
+
 Create whitelists to tackle false positives in Vulture automatically for
 frameworks using Python bindings for C and C++ libraries, e.g. PyQt.
 


### PR DESCRIPTION
Coveralls is reporting coverage to be 'unknown' - If this is due to the current configuration, codecov should also give similar output.